### PR TITLE
Make displayed results case sensitive

### DIFF
--- a/jquery.typeahead.js
+++ b/jquery.typeahead.js
@@ -563,8 +563,8 @@
                                     );
                                 }
 
-                                _display = result.display.toLowerCase();
-                                _query = query.toLowerCase();
+                                _display = result.display;
+                                _query = query;
 
                                 if (options.accent) {
                                     _display = _removeAccent(_display);
@@ -1502,7 +1502,7 @@
          * @returns {*}
          */
         var _highlight = function (string, key) {
-            var offset = string.indexOf(key);
+            var offset = string.toLowerCase().indexOf(key.toLowerCase());
 
             if (offset === -1) {
                 return string;


### PR DESCRIPTION
Force changing data results to lowercase makes them technically incorrect compared to the original dataset. This minor edit shows the dropdown results in their original case, but still changes to lowercase for checking where to highlight text.