### PR TITLE
Add UMD wrapper

### DIFF
--- a/src/jquery.typeahead.js
+++ b/src/jquery.typeahead.js
@@ -8,7 +8,17 @@
  * @link http://www.runningcoder.org/jquerytypeahead/
 */
 ;
-(function (window, document, $, undefined) {
+(function (factory) {
+  if (typeof define === 'function' && define.amd) {
+    define(['jquery'], function (jQuery) {
+      factory(window, document, jQuery);
+    });
+  } else if (typeof exports === 'object') {
+    module.exports = factory(window, document, require('jquery'));
+  } else {
+    factory(window, document, window.jQuery);
+  }
+})(function (window, document, $, undefined) {
 
     window.Typeahead = {
         version: '2.1.3'
@@ -2346,4 +2356,4 @@
         };
     }
 
-}(window, document, window.jQuery));
+});


### PR DESCRIPTION
By adding an UMD wrapper, we'd be able to require `jquery.typeahead` from RequireJS, Browserify, Webpack, etc.