### PR TITLE
First check that we find an input before accessing found elements

### DIFF
--- a/src/jquery.typeahead.js
+++ b/src/jquery.typeahead.js
@@ -3780,9 +3780,6 @@
 
                 node = $(options.input);
             }
-            if (typeof node[0].value === "undefined") {
-                node[0].value = node.text();
-            }
             if (!node.length) {
                 // {debug}
                 _debug.log({
@@ -3796,6 +3793,9 @@
                 // {/debug}
 
                 return;
+            }
+            if (typeof node[0].value === "undefined") {
+                node[0].value = node.text();
             }
 
             // #270 Forcing node.selector, the property was deleted from jQuery3


### PR DESCRIPTION
Hello!
I tried out jquery-typeahead and it's great! However, I accidentally wrote the wrong class on my input and got an error could not read value from undefined. Of course it couldn't find my input, but it seemed the array of found inputs was accessed before checking that we got any hits.
I spent some time on this before I found out what was wrong, it would be got to get the correct error message.

Thanks!
Michael