### PR TITLE
Remove any backdrop elements if existing before building a new one

### DIFF
--- a/src/jquery.typeahead.js
+++ b/src/jquery.typeahead.js
@@ -2574,6 +2574,7 @@
             if (!this.options.backdrop) return;
 
             if (!this.backdrop.container) {
+                this.container.siblings('.' + this.options.selector.backdrop).remove();
                 this.backdrop.css = $.extend(
                     {
                         opacity: 0.6,


### PR DESCRIPTION
I'm working with a single page application (Angular) and between routes I lose the state if any backdrop has been created so next time one searches the element exists in the DOM but this.backdrop doesn't contain anything.
This causes the application to create two backdrop elements and one of them will not disappear and hence you cannot use your page and are forced to do a hard refresh of the page.
With this fix I delete any siblings with the backdrop selector so there never will be any duplicates.