### PR TITLE
Add option to select item on tab key press

### DIFF
--- a/example/demo-beer_v1.html
+++ b/example/demo-beer_v1.html
@@ -139,6 +139,7 @@
             maxItem: 15,
             order: "asc",
             hint: true,
+            selectWithTab: true,
             group: {
                 template: "{{group}} beers!"
             },

--- a/example/demo-country_v2.html
+++ b/example/demo-country_v2.html
@@ -142,6 +142,7 @@
                 });
             },
             hint: true,
+            selectWithTab: true,
             dropdownFilter: "All",
             href: "https://en.wikipedia.org/?title={{display}}",
             template: "{{display}}, <small><em>{{group}}</em></small>",

--- a/src/jquery.typeahead.js
+++ b/src/jquery.typeahead.js
@@ -48,6 +48,7 @@
         order: null,                // "asc" or "desc" to sort results
         offset: false,              // Set to true to match items starting from their first character
         hint: false,                // Added support for excessive "space" characters
+        selectWithTab: false,       // Select item on tab key press
         accent: false,              // Will allow to type accent and give letter equivalent results, also can define a custom replacement object
         highlight: true,            // Added "any" to highlight any word in the template, by default true will only highlight display keys
         multiselect: null,          // Multiselect configuration object, see documentation for all options
@@ -1618,7 +1619,12 @@
                 return;
             }
 
-            if (e.keyCode === 39) {
+            var selectKeyCodes = [39];
+            if (this.options.selectWithTab === true) {
+                selectKeyCodes = [9, 39];
+            }
+
+            if (selectKeyCodes.indexOf(e.keyCode) !== -1) {
                 if (activeItemIndex !== null) {
                     itemList
                         .eq(activeItemIndex)


### PR DESCRIPTION
Possibly related to https://github.com/running-coder/jquery-typeahead/issues/232

Hello!
I think it would be nice to have an option to select the autocompleted items by using up and down arrows and confirm using the tab key.

With my PR the plugin's default behavior would remain the same, but if you set the value of the new `selectWithTab` option to true, then you would be able to do that.

I've updated a couple of demo examples for testing purposes.